### PR TITLE
VuePress を GitHub Pages に自動デプロイするワークフローの実装

### DIFF
--- a/.github/workflows/vuepress.yml
+++ b/.github/workflows/vuepress.yml
@@ -45,3 +45,8 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: dist
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./
+          publish_branch: gh-pages

--- a/.github/workflows/vuepress.yml
+++ b/.github/workflows/vuepress.yml
@@ -36,10 +36,9 @@ jobs:
         path: docs/.vuepress/dist
 
   deploy:
+  
     runs-on: ubuntu-latest
     needs: build
-    environment:
-      name: dev
     steps:
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/vuepress.yml
+++ b/.github/workflows/vuepress.yml
@@ -20,7 +20,7 @@ defaults:
     
 jobs:
   build:
-
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -38,7 +38,7 @@ jobs:
         path: docs/dist
 
   deploy:
-  
+    if: github.event_name == 'push' # PR 時はデプロイを実行しない
     runs-on: ubuntu-latest
     needs: build
     steps:

--- a/.github/workflows/vuepress.yml
+++ b/.github/workflows/vuepress.yml
@@ -48,5 +48,5 @@ jobs:
       - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./
+          publish_dir: .
           publish_branch: gh-pages

--- a/.github/workflows/vuepress.yml
+++ b/.github/workflows/vuepress.yml
@@ -1,0 +1,28 @@
+name: VuePress CI/CD
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/vuepress.yml'
+      - 'docs/**'
+
+defaults:
+  run:
+    working-directory: docs
+    
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14.x'
+        cache: 'npm'
+        cache-dependency-path: docs/package-lock.json
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm test

--- a/.github/workflows/vuepress.yml
+++ b/.github/workflows/vuepress.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - '.github/workflows/vuepress.yml'
       - 'docs/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/vuepress.yml'
+      - 'docs/**'
 
 defaults:
   run:
@@ -25,4 +30,7 @@ jobs:
         cache-dependency-path: docs/package-lock.json
     - run: npm ci
     - run: npm run build --if-present
-    - run: npm test
+    - uses: actions/upload-artifact@v2
+      with:
+        name: dist
+        path: docs/dist

--- a/.github/workflows/vuepress.yml
+++ b/.github/workflows/vuepress.yml
@@ -33,4 +33,4 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: dist
-        path: docs/dist
+        path: docs/.vuepress/dist

--- a/.github/workflows/vuepress.yml
+++ b/.github/workflows/vuepress.yml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: dist
-        path: dist
+        path: docs/dist
 
   deploy:
   

--- a/.github/workflows/vuepress.yml
+++ b/.github/workflows/vuepress.yml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: dist
-        path: docs/.vuepress/dist
+        path: dist
 
   deploy:
   

--- a/.github/workflows/vuepress.yml
+++ b/.github/workflows/vuepress.yml
@@ -7,7 +7,7 @@ on:
       - '.github/workflows/vuepress.yml'
       - 'docs/**'
   pull_request:
-    branches: [main]
+    branches: [　main ]
     paths:
       - '.github/workflows/vuepress.yml'
       - 'docs/**'
@@ -34,3 +34,13 @@ jobs:
       with:
         name: dist
         path: docs/.vuepress/dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: dev
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist

--- a/.github/workflows/vuepress.yml
+++ b/.github/workflows/vuepress.yml
@@ -2,12 +2,14 @@ name: VuePress CI/CD
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - '.github/workflows/vuepress.yml'
       - 'docs/**'
   pull_request:
-    branches: [　main ]
+    branches:
+      - main
     paths:
       - '.github/workflows/vuepress.yml'
       - 'docs/**'

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,5 @@
-.vuepress/
+.vuepress/*
+!.vuepress/config.js
 images/
 node_modules/
+dist/

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    title: "Vue3 Handson",
+    description: "Vue.js-jp Vue3 Handson",
+    dest: "dist/",
+    base: '/handson-vue3/',
+};

--- a/docs/create.md
+++ b/docs/create.md
@@ -50,7 +50,7 @@
 
 1. ブラウザに「Welcome to Your Vue.js App」等と表示されていれば、無事にプロジェクトの作成が成功しています。
 
-   ![vue-app](images/vue-app.png)
+   ![vue-app](./images/vue-app.png)
 
    `vue create` コマンドの詳細は [Creating a Project \| Vue CLI](https://cli.vuejs.org/guide/creating-a-project.html) を確認してください。
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -4,7 +4,7 @@
 
 このハンズオンでは、簡単な商品の一覧を表示し、購入する商品を選択できるプログラムを作成します。プログラムを作成する過程で、 Vue.js の基本を学ぶことができます。実際に動く物は <a href="hogehoge">こちら</a> から見れます。
 
-![vue-app](images/sample.png)
+![vue-app](./images/sample.png)
 
 ## 作成の流れ
 

--- a/docs/v-for.md
+++ b/docs/v-for.md
@@ -44,7 +44,7 @@ var app = new Vue({
 ・タスクC
 ```
 
-![v-for 構文の出力例](images/v_for_result1.png)
+![v-for 構文の出力例](./images/v_for_result1.png)
 
 ## 複数の商品をレンダリング
 プロジェクトのファイルを書き換えて、複数の商品をレンダリングしていきましょう。`App.vue` ファイルを次のように変更します。
@@ -148,7 +148,7 @@ export default {
   </main>
 ```
 
-![複数の商品をレンダリングの出力例](images/v_for_result2.png)
+![複数の商品をレンダリングの出力例](./images/v_for_result2.png)
 
 これで、商品を複数レンダリングできました。
 


### PR DESCRIPTION
- [x] PR 時に VuePress をビルドする
  - Markdown 内の画像相対パスを `./xxx` 形式に変更（VuePress の相対パス仕様） 
  - `./vuepress/config.js` を作成し、デプロイ時のベースパスを設定
- [x] Merge 時に VuePress を GitHub Pages にデプロイする