### PR TITLE
docs: Vue CLI を 4.5.13 に変更した手順に変更

### DIFF
--- a/docs/create.md
+++ b/docs/create.md
@@ -14,27 +14,32 @@
 
 1. Vue CLI でプロジェクトを新規作成します。ターミナルで以下のコマンドを実行します（コマンド実行後はそのまま待機しておいてください）。プロジェクトのディレクトリは Vue CLI によって自動的に作成されます。
 
-   ```sh
-   vue create vue3-lab
-   ```
+   > なお、このハンズオンでは `Vue CLI v4.5.13` を使用して説明しています。
 
-1. 実行後のプロンプト `Please pick a preset` では、このワークショップでは以下のように `Default (Vue 3 Preview)` を選択します。
+```sh
+vue create vue3-lab
+```
+
+1. 実行後のプロンプト `Please pick a preset` では、このワークショップでは以下のように `Default (Vue 3) ([Vue 3] babel, eslint) ` を選択します。
 
    > プロンプト内では、矢印キーで移動、Space キーで選択、Enter キーで確定ができます
 
    ```sh
+   Vue CLI v4.5.13
    ? Please pick a preset:
      Default ([Vue 2] babel, eslint)
-     ❯ Default (Vue 3 Preview) ([Vue 3] babel, eslint)
+   ❯ Default (Vue 3) ([Vue 3] babel, eslint)
      Manually select features
    ```
 
 1. 次のプロンプト `Pick the package manager to use when installing dependencies:` では、好みのパッケージマネージャーを選んでください。（このハンズオンでは、npm を前提に説明を進めますので、適宜読み替えてください）
 
    ```sh
-   ? Pick the package manager to use when installing dependencies:
-   Use Yarn
-   ❯ Use NPM
+   Vue CLI v4.5.13
+   ? Please pick a preset: Default (Vue 3) ([Vue 3] babel, eslint)
+   ? Pick the package manager to use when installing dependencies: 
+     Use Yarn 
+   ❯ Use NPM 
    ```
 
 ## プロジェクトの起動


### PR DESCRIPTION
#65 で指摘があったように、現時点でインストールされる Vue CLI に合わせた方が受講者の画面と同一になるため、Vue CLI を `4.5.13` に変更した説明に変えました。