### PR TITLE
`v-for` と `v-if` のガイド内のタグを修正

### DIFF
--- a/docs/v-for.md
+++ b/docs/v-for.md
@@ -138,6 +138,7 @@ export default {
 +      <div class="item">
 +         <div class="thumbnail">
 +            <img :src="item.image" alt="" />
++         </div>
 +      </div>
 +      <div class="description">
 +        <h2>{{ item.name }}</h2>

--- a/docs/v-if.md
+++ b/docs/v-if.md
@@ -113,7 +113,7 @@ JavaScript の条件分岐の構文に `else` があるように、Vue.js にも
 <div v-if="!item.soldOut">
   <!-- 省略 -->
 </div>
-<div v-slse>売り切れです</div>
+<div v-else>売り切れです</div>
 ```
 
 また、JavaScript の `else if` と同様の働きをする `v-else-if` も用意されています。

--- a/docs/v-if.md
+++ b/docs/v-if.md
@@ -64,7 +64,7 @@ Vue.js では特定の条件の時だけ DOM を生成し表示することが�
 <template>
   <!-- 省略 -->
   <main class="main">
-    <template v-for="item in items" :key="item.id">
+    <div v-for="item in items" :key="item.id">
       <!-- ここから商品表示 -->
       <div class="item">
         <div class="thumbnail">
@@ -76,7 +76,7 @@ Vue.js では特定の条件の時だけ DOM を生成し表示することが�
           <span>¥<span class="price">item.price</span></span>
         </div>
       </div>
-    </template>
+    </div>
   </main>
 </template>
 ```


### PR DESCRIPTION
#65 関連。以下に対応しました。
- `v-vor.md` の閉じタグ不足
- `v-if.md` の `template` から `div` への変更漏れ