### PR TITLE
GitHub Pages でカスタムドメインを利用する

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -2,7 +2,7 @@ module.exports = {
     title: "Vue3 Hands-on",
     description: "Vue.js-jp Vue3 Hands-on",
     dest: "dist/",
-    base: '/handson-vue3/',
+    base: '/',
     themeConfig: {
         sidebar: [
             '/',


### PR DESCRIPTION
https://handson.vuejs-jp.org/ で表示されるように VuePress の Base を `/` に変更しました。

参考にしたドキュメント
- https://vuepress.vuejs.org/guide/deploy.html?#github-pages