### PR TITLE
chore: formatter の設定を最適化

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_size = 2
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
     'node': true
   },
   'extends': [
-    'plugin:vue/vue3-essential',
+    'plugin:vue/vue3-recommended',
     'eslint:recommended',
     'prettier',
   ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,31 +5,18 @@ module.exports = {
   },
   'extends': [
     'plugin:vue/vue3-essential',
-    'eslint:recommended'
+    'eslint:recommended',
+    'prettier',
   ],
   'parserOptions': {
     'parser': 'babel-eslint'
   },
   'rules': {
-    'semi': [
-      'error',
-      'never'
-    ],
-    'quotes': [
-      'error',
-      'single'
-    ],
-    'comma-dangle': [
-      'error',
-      'never'
-    ],
-    'comma-style': [
-      'error',
-      'last'
-    ],
     'vue/html-closing-bracket-newline': ['error', {
       'singleline': 'never',
       'multiline': 'never'
-    }]
+    }],
+    'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
+    'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ pnpm-debug.log*
 
 # Editor directories and files
 .idea
-.vscode
 *.suo
 *.ntvs*
 *.njsproj

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 /dist
+/docs/dist
 
 
 # local env files

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,3 @@
 module.exports = {
   singleQuote: true,
-  printWidth: 120
 }

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,6 +1,4 @@
 module.exports = {
-  trailingComma: 'none',
-  tabWidth: 2,
-  semi: false,
-  singleQuote: true
+  singleQuote: true,
+  printWidth: 120
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
+}

--- a/examples/event/src/App.vue
+++ b/examples/event/src/App.vue
@@ -1,17 +1,23 @@
 <template>
   <header class="header">
-    <img src="/images/logo.svg" alt="" />
+    <img
+      src="/images/logo.svg"
+      alt="">
     <h1>Vue.js ハンズオン</h1>
   </header>
   <main class="main">
-    <template v-for="item in items" :key="item.id">
+    <template
+      v-for="item in items"
+      :key="item.id">
       <div
         v-if="!item.soldOut"
         class="item"
         :class="{ 'selected-item': item.selected }"
         @click="item.selected = !item.selected">
         <div class="thumbnail">
-          <img :src="item.image" alt="" />
+          <img
+            :src="item.image"
+            alt="">
         </div>
         <div class="description">
           <h2>{{ item.name }}</h2>

--- a/examples/methods/src/App.vue
+++ b/examples/methods/src/App.vue
@@ -1,13 +1,21 @@
 <template>
   <header class="header">
-    <img src="/images/logo.svg" alt="" />
+    <img
+      src="/images/logo.svg"
+      alt="">
     <h1>Vue.js ハンズオン</h1>
   </header>
   <main class="main">
-    <template v-for="item in items" :key="item.id">
-      <div v-if="!item.soldOut" class="item">
+    <template
+      v-for="item in items"
+      :key="item.id">
+      <div
+        v-if="!item.soldOut"
+        class="item">
         <div class="thumbnail">
-          <img :src="item.image" alt="" />
+          <img
+            :src="item.image"
+            alt="">
         </div>
         <div class="description">
           <h2>{{ item.name }}</h2>

--- a/examples/overview/src/App.vue
+++ b/examples/overview/src/App.vue
@@ -1,5 +1,7 @@
 <template>
-  <img alt="Vue logo" src="./assets/logo.png" />
+  <img
+    alt="Vue logo"
+    src="./assets/logo.png">
   <HelloWorld msg="Welcome to Your Vue.js App" />
 </template>
 

--- a/examples/overview/src/components/HelloWorld.vue
+++ b/examples/overview/src/components/HelloWorld.vue
@@ -2,11 +2,12 @@
   <div class="hello">
     <h1>{{ msg }}</h1>
     <p>
-      For a guide and recipes on how to configure / customize this project,<br />
+      For a guide and recipes on how to configure / customize this project,<br>
       check out the
-      <a href="https://cli.vuejs.org" target="_blank" rel="noopener"
-        >vue-cli documentation</a
-      >.
+      <a
+        href="https://cli.vuejs.org"
+        target="_blank"
+        rel="noopener">vue-cli documentation</a>.
     </p>
     <h3>Installed CLI Plugins</h3>
     <ul>
@@ -14,73 +15,79 @@
         <a
           href="https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-babel"
           target="_blank"
-          rel="noopener"
-          >babel</a
-        >
+          rel="noopener">babel</a>
       </li>
       <li>
         <a
           href="https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-eslint"
           target="_blank"
-          rel="noopener"
-          >eslint</a
-        >
+          rel="noopener">eslint</a>
       </li>
     </ul>
     <h3>Essential Links</h3>
     <ul>
       <li>
-        <a href="https://vuejs.org" target="_blank" rel="noopener">Core Docs</a>
+        <a
+          href="https://vuejs.org"
+          target="_blank"
+          rel="noopener">Core Docs</a>
       </li>
       <li>
-        <a href="https://forum.vuejs.org" target="_blank" rel="noopener"
-          >Forum</a
-        >
+        <a
+          href="https://forum.vuejs.org"
+          target="_blank"
+          rel="noopener">Forum</a>
       </li>
       <li>
-        <a href="https://chat.vuejs.org" target="_blank" rel="noopener"
-          >Community Chat</a
-        >
+        <a
+          href="https://chat.vuejs.org"
+          target="_blank"
+          rel="noopener">Community Chat</a>
       </li>
       <li>
-        <a href="https://twitter.com/vuejs" target="_blank" rel="noopener"
-          >Twitter</a
-        >
+        <a
+          href="https://twitter.com/vuejs"
+          target="_blank"
+          rel="noopener">Twitter</a>
       </li>
       <li>
-        <a href="https://news.vuejs.org" target="_blank" rel="noopener">News</a>
+        <a
+          href="https://news.vuejs.org"
+          target="_blank"
+          rel="noopener">News</a>
       </li>
     </ul>
     <h3>Ecosystem</h3>
     <ul>
       <li>
-        <a href="https://router.vuejs.org" target="_blank" rel="noopener"
-          >vue-router</a
-        >
+        <a
+          href="https://router.vuejs.org"
+          target="_blank"
+          rel="noopener">vue-router</a>
       </li>
       <li>
-        <a href="https://vuex.vuejs.org" target="_blank" rel="noopener">vuex</a>
+        <a
+          href="https://vuex.vuejs.org"
+          target="_blank"
+          rel="noopener">vuex</a>
       </li>
       <li>
         <a
           href="https://github.com/vuejs/vue-devtools#vue-devtools"
           target="_blank"
-          rel="noopener"
-          >vue-devtools</a
-        >
+          rel="noopener">vue-devtools</a>
       </li>
       <li>
-        <a href="https://vue-loader.vuejs.org" target="_blank" rel="noopener"
-          >vue-loader</a
-        >
+        <a
+          href="https://vue-loader.vuejs.org"
+          target="_blank"
+          rel="noopener">vue-loader</a>
       </li>
       <li>
         <a
           href="https://github.com/vuejs/awesome-vue"
           target="_blank"
-          rel="noopener"
-          >awesome-vue</a
-        >
+          rel="noopener">awesome-vue</a>
       </li>
     </ul>
   </div>
@@ -90,7 +97,8 @@
 export default {
   name: 'HelloWorld',
   props: {
-    msg: String
+    // eslint-disable-next-line vue/require-default-prop
+    msg: String,
   }
 }
 </script>

--- a/examples/rendering/src/App.vue
+++ b/examples/rendering/src/App.vue
@@ -1,13 +1,17 @@
 // region template
 <template>
   <header class="header">
-    <img src="/images/logo.svg" alt="" />
+    <img
+      src="/images/logo.svg"
+      alt="">
     <h1>Vue.js ハンズオン</h1>
   </header>
   <main class="main">
     <div class="item">
       <div class="thumbnail">
-        <img :src="item.image" alt="" />
+        <img
+          :src="item.image"
+          alt="">
       </div>
       <div class="description">
         <h2>{{ item.name }}</h2>

--- a/examples/v-for/src/App.vue
+++ b/examples/v-for/src/App.vue
@@ -1,14 +1,20 @@
 // region template
 <template>
   <header class="header">
-    <img src="/images/logo.svg" alt="" />
+    <img
+      src="/images/logo.svg"
+      alt="">
     <h1>Vue.js ハンズオン</h1>
   </header>
   <main class="main">
-    <template v-for="item in items" :key="item.id">
+    <template
+      v-for="item in items"
+      :key="item.id">
       <div class="item">
         <div class="thumbnail">
-          <img :src="item.image" alt="" />
+          <img
+            :src="item.image"
+            alt="">
         </div>
         <div class="description">
           <h2>{{ item.name }}</h2>

--- a/examples/v-if/src/App.vue
+++ b/examples/v-if/src/App.vue
@@ -1,13 +1,21 @@
 <template>
   <header class="header">
-    <img src="/images/logo.svg" alt="" />
+    <img
+      src="/images/logo.svg"
+      alt="">
     <h1>Vue.js ハンズオン</h1>
   </header>
   <main class="main">
-    <template v-for="item in items" :key="item.id">
-      <div v-if="!item.soldOut" class="item">
+    <template
+      v-for="item in items"
+      :key="item.id">
+      <div
+        v-if="!item.soldOut"
+        class="item">
         <div class="thumbnail">
-          <img :src="item.image" alt="" />
+          <img
+            :src="item.image"
+            alt="">
         </div>
         <div class="description">
           <h2>{{ item.name }}</h2>

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@vue/eslint-config-prettier": "6.0.0",
         "babel-eslint": "10.1.0",
         "eslint": "6.8.0",
-        "eslint-plugin-prettier": "3.3.1",
         "eslint-plugin-vue": "8.2.0",
         "prettier": "2.5.1",
         "textlint": "12.1.0",
@@ -6917,6 +6916,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz",
       "integrity": "sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0"
       },
@@ -7633,7 +7633,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/fast-glob": {
       "version": "2.2.7",
@@ -12744,6 +12745,7 @@
       "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
       "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-diff": "^1.1.2"
       },
@@ -23837,6 +23839,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz",
       "integrity": "sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
       }
@@ -24319,7 +24322,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "fast-glob": {
       "version": "2.2.7",
@@ -28376,6 +28380,7 @@
       "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
       "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
       "dev": true,
+      "peer": true,
       "requires": {
         "fast-diff": "^1.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "lint": "prettier --check . && eslint --ext .ts,.js,.vue --ignore-path .gitignore .",
+    "lint": "eslint --ext .ts,.js,.vue --ignore-path .gitignore .",
     "textlint": "textlint --format pretty-error",
     "textlint:docs": "textlint --format pretty-error docs/**"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint",
+    "lint": "prettier --check . && eslint --ext .ts,.js,.vue --ignore-path .gitignore .",
     "textlint": "textlint --format pretty-error",
     "textlint:docs": "textlint --format pretty-error docs/**"
   },
@@ -21,7 +21,6 @@
     "@vue/eslint-config-prettier": "6.0.0",
     "babel-eslint": "10.1.0",
     "eslint": "6.8.0",
-    "eslint-plugin-prettier": "3.3.1",
     "eslint-plugin-vue": "8.2.0",
     "prettier": "2.5.1",
     "textlint": "12.1.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,17 +1,23 @@
 <template>
   <header class="header">
-    <img src="/images/logo.svg" alt="" />
+    <img
+      src="/images/logo.svg"
+      alt="">
     <h1>Vue.js ハンズオン</h1>
   </header>
   <main class="main">
-    <template v-for="item in items" :key="item.id">
+    <template
+      v-for="item in items"
+      :key="item.id">
       <div
         v-if="!item.soldOut"
         class="item"
         :class="{ 'selected-item': item.selected }"
         @click="item.selected = !item.selected">
         <div class="thumbnail">
-          <img :src="item.image" alt="" />
+          <img
+            :src="item.image"
+            alt="">
         </div>
         <div class="description">
           <h2>{{ item.name }}</h2>


### PR DESCRIPTION
サンプルコードやガイドを保存する際に開発環境によって意図しないフォーマットが効いていたことがあったので、できるだけどの環境で保存しても同じになるように調整してみました。主な変更点は以下です。

- `.editorconfig` の導入
- eslint の prettier プラグインが非推奨になったことへの対応
- eslint のルールで `vue/vue3-recommended` を使ってチェックを強化
- 上記設定を反映してサンプルコードを再フォーマット