### PR TITLE
v-forの章内で 「状態の維持」 へのリンクが切れていたため解消

### DIFF
--- a/docs/v-for.md
+++ b/docs/v-for.md
@@ -63,7 +63,7 @@ const tasks = ref([
 
 <<< @/../examples/v-for/src/App.vue#template{9-24}
 
-同時に指定している `key` 属性は、 `v-for` で取り出した各要素を一意（ユニーク）にするために推奨されているものです。一意にすることで、 Vue.js が要素の再利用や並び替えをする手助けになります。 詳細は [Vue.jsドキュメントガイド 状態の維持](https://v3.ja.vuejs.org/guide/list.html#%E7%8A%B6%E6%85%8B%E3%81%AE%E7%B6%AD%E6%8C%81 "Vue.jsドキュメントガイド 状態の維持")を参照してください。 
+同時に指定している `key` 属性は、 `v-for` で取り出した各要素を一意（ユニーク）にするために推奨されているものです。一意にすることで、 Vue.js が要素の再利用や並び替えをする手助けになります。 詳細は [Vue.jsドキュメントガイド key による状態管理](https://ja.vuejs.org/guide/essentials/list.html#maintaining-state-with-key "Vue.jsドキュメントガイド key による状態管理")を参照してください。
 
 ::: tip ヒント
 v-for を使った template タグは DOM 要素としてレンダリングされません。


### PR DESCRIPTION
close #209 
公式ドキュメントがVue3になったタイミングでリンク切れを起こしたと推測されます。
まったく同じ内容は存在しないため、以下のリンク先を再設定しました。
■修正前
[状態の維持](https://v2.ja.vuejs.org/v2/guide/list.html#%E7%8A%B6%E6%85%8B%E3%81%AE%E7%B6%AD%E6%8C%81)
■修正後
[key による状態管理](https://ja.vuejs.org/guide/essentials/list.html#maintaining-state-with-key)