### PR TITLE
eventの章内で 「イベントに関する詳細」 へのリンクが切れていたため解消

### DIFF
--- a/docs/event.md
+++ b/docs/event.md
@@ -79,7 +79,7 @@ Vue.js でイベントリスナーを登録するには `v-on` というディ�
 <button type="button" @click="イベント時の処理">***</button>
 ```
 
-- [イベントに関する詳細](https://v3.ja.vuejs.org/guide/events.html)
+- [イベントに関する詳細](https://ja.vuejs.org/guide/essentials/event-handling.html)
 
 ### click イベントの実装
 


### PR DESCRIPTION
close #210
リンク切れを起こす前のページが見つからなかったため、公式ドキュメント内から適していると思われるリンクを再設定
■設定URL
https://ja.vuejs.org/guide/essentials/event-handling.html